### PR TITLE
corrected "arb" lang code mapping to ms arabic

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,7 +4,7 @@ Part of SONAR models are released with MIT license too:
 
 | lang_code | language         | url                                                               |
 | --------- | ---------------- | ------------------------------------------------------ |
-| arb       | afrikaans        | https://dl.fbaipublicfiles.com/SONAR/spenc.v3ap.arb.pt |
+| arb       | ms arabic        | https://dl.fbaipublicfiles.com/SONAR/spenc.v3ap.arb.pt |
 | cat       | catalan          | https://dl.fbaipublicfiles.com/SONAR/spenc.v3ap.cat.pt |
 | cym       | welsh            | https://dl.fbaipublicfiles.com/SONAR/spenc.v3ap.cym.pt |
 | dan       | danish           | https://dl.fbaipublicfiles.com/SONAR/spenc.v3ap.dan.pt |

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ All 200 languages from the [No Language Left Behind project](https://arxiv.org/a
 
 | lang_code | language         | link                                                               |
 | --------- | ---------------- | ------------------------------------------------------------------ |
-| arb       | afrikaans        | [download](https://dl.fbaipublicfiles.com/SONAR/spenc.v3ap.arb.pt) |
+| arb       | ms arabic        | [download](https://dl.fbaipublicfiles.com/SONAR/spenc.v3ap.arb.pt) |
 | asm       | assamese         | [download](https://dl.fbaipublicfiles.com/SONAR/spenc.v5ap.asm.pt) |
 | bel       | belarussian      | [download](https://dl.fbaipublicfiles.com/SONAR/spenc.v5ap.bel.pt) |
 | ben       | bengali          | [download](https://dl.fbaipublicfiles.com/SONAR/spenc.v5ap.ben.pt) |


### PR DESCRIPTION
lang code "arb" maps to MS Arabic according to the paper. corrected it in README and LICENSE