### PR TITLE
Add dependencies installation on the notebook

### DIFF
--- a/examples/inference_pipelines.ipynb
+++ b/examples/inference_pipelines.ipynb
@@ -16,6 +16,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Install sonar\n",
+    "\n",
+    "if sonar is not yet installed, install it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install sonar-space"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Setup common config"
    ]
   },

--- a/examples/sonar_text_demo.ipynb
+++ b/examples/sonar_text_demo.ipynb
@@ -4,6 +4,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Install the dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install sonar-space seaborn pandas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### We first instantiate text pipelines that'll load sonar text encoder and decoder models (it'll take ~ 30 seconds)"
    ]
   },


### PR DESCRIPTION
## Why ?

Why do we need to implement this feature ? What is the use case ?
In order to be able to run the notebooks (on colab for example), we need to install the python dependencies.

## How ?
This contribution adds a cell on the notebooks and uses pip to install the requirements in order to be able to run the experiments.

