### PR TITLE
add overrides deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "sox",
   "soundfile",
   "tqdm",
+  "overrides",
   "typing_extensions",
 ]
 


### PR DESCRIPTION
## Why ?

SONAR code uses overrides https://github.com/facebookresearch/SONAR/blob/main/sonar/nn/encoder_pooler.py#L16 but this lib is not in the dependencies list. 

This breaks a few CI test in other (fairinternal) repo depending on this repo

