### PR TITLE
Update sonar_text_demo.ipynb

### DIFF
--- a/examples/sonar_text_demo.ipynb
+++ b/examples/sonar_text_demo.ipynb
@@ -189,12 +189,12 @@
     "import sacrebleu\n",
     "bleu_obj = sacrebleu.corpus_bleu(french_translated_sentences, [french_sentences], tokenize='flores200')\n",
     "print(\"*\" * 120)\n",
-    "print(\"english to spanish translation bleu score :\")\n",
+    "print(\"english to french translation bleu score :\")\n",
     "print(bleu_obj)\n",
     "\n",
     "bleu_obj = sacrebleu.corpus_bleu(english_translated_sentences, [english_sentences], tokenize='flores200')\n",
     "print(\"*\" * 120)\n",
-    "print(\"spanish to english translation bleu score :\")\n",
+    "print(\"french to english translation bleu score :\")\n",
     "print(bleu_obj)\n"
    ]
   },


### PR DESCRIPTION
Wrong language typo

## Why ?

There is a minor typo at the end of the notebook that mentions 'spanish' as translation language when it's actually French.

## How ?

NA

## Test plan

NA
