### PR TITLE
Update the `black` dependency version to avoid a vulnerability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
       "pytest-cov>=2.6.1",
       "coverage[toml]>=5.1",
       # Format
-      "black==22.3.0",
+      "black==24.3.0",
       "isort>=5.10.1",
       # Linters
       "mypy>=0.782",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ pytest-asyncio>=0.15.0
 pytest-cov>=2.6.1
 coverage[toml]>=5.1
 # Format
-black==22.3.0
+black==24.3.0
 isort>=5.10.1
 # Linter
 mypy>=0.782


### PR DESCRIPTION
## Why ?

Fixing https://github.com/facebookresearch/SONAR/security/dependabot/1.
See https://github.com/advisories/GHSA-fj7x-q9j7-g6q6.

## How ?
Upgrade the `black` dependency version.

## Test plan

The automatic test suite. 
