### PR TITLE
Fix black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
       "pytest-cov>=2.6.1",
       "coverage[toml]>=5.1",
       # Format
-      "black==22.3.0",
+      "black",
       "isort>=5.10.1",
       # Linters
       "mypy>=0.782",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ pytest-asyncio>=0.15.0
 pytest-cov>=2.6.1
 coverage[toml]>=5.1
 # Format
-black==22.3.0
+black
 isort>=5.10.1
 # Linter
 mypy>=0.782


### PR DESCRIPTION
## Why ?

Old version of black has some security holes that are vulnerable to attacks:

https://nvd.nist.gov/vuln/detail/CVE-2024-21503
https://github.com/psf/black/commit/f00093672628d212b8965a8993cee8bedf5fe9b8
https://github.com/psf/black/releases/tag/24.3.0
https://security.snyk.io/vuln/SNYK-PYTHON-BLACK-6256273
https://github.com/pypa/advisory-database/tree/main/vulns/black/PYSEC-2024-48.yaml
https://github.com/advisories/GHSA-fj7x-q9j7-g6q6

## How ?

This PR removes he fixed versioning in black deps, so it automatically upgrades to the fixed version (24.3.0 or later)

## Test plan

Check CI
