### PR TITLE
Modified the import of load_nllb_tokenizer

### DIFF
--- a/sonar/models/sonar_text/loader.py
+++ b/sonar/models/sonar_text/loader.py
@@ -9,7 +9,7 @@ from typing import Any, Dict
 import torch
 from fairseq2.models.config_loader import StandardModelConfigLoader
 from fairseq2.models.loader import StandardModelLoader, load_model
-from fairseq2.models.nllb import load_nllb_tokenizer
+from fairseq2.data.text.tokenizers.nllb import load_nllb_tokenizer
 from fairseq2.models.utils.checkpoint import convert_fairseq_checkpoint
 
 from sonar.models.sonar_text.builder import (


### PR DESCRIPTION
Changed from fairseq2.models.nllb import load_nllb_tokenizer with from fairseq2.data.text.tokenizers.nllb import load_nllb_tokenizer on the sonar/models/sonar_text/loader.py file #53 Ig also resolves  #52 


## Why ?

Why do we need to implement this feature? What is the use case ?

This feature needs to be implemented because the latest fairseq library has the load_nllb_tokenizer in a different file, which has not been updated in the repo yet. The use case of this is to ensure no import errors while computing text sentence embeddings with SONAR.

## How ?

Replace **from fairseq2.models.nllb import load_nllb_tokenize**r
with **from fairseq2.data.text.tokenizers.nllb import load_nllb_tokenizer**
on the **sonar/models/sonar_text/loader.py** file

Document the technical decisions you made.
When I read the paper on **Large Concept Models** by **Meta**, I was eager to implement it. So, I immediately installed the SONAR package to try it out and compute text sentence embeddings for my Agentic RAG for Financial Documents project. But I got an error message about the package import from the Fairseq library. So I uninstalled and installed it again, and I still got it. So, I decided to check out the codebase for bugs and found this.

