### PR TITLE
Fix pip cache in Github CI by updating an action version

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -96,7 +96,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"


### PR DESCRIPTION
## Why ?

**Problem**: Github CI is failing.
We are getting errors like this one [here](https://github.com/facebookresearch/SONAR/actions/runs/16576110049/job/46880675849):
```
Run actions/setup-python@v3
  with:
    python-version: 3.10
    cache: pip
    token: ***
Successfully setup CPython (3.10.18)
/opt/hostedtoolcache/Python/3.10.18/x64/bin/pip cache dir
/home/runner/.cache/pip
Error: Cache service responded with 400
```
So we should do something about the pip cache. 

## How ?

Apparently, we were using an outdated version of the `setup-python` action. When updating it from v3 to v4, the cache service error goes away. 

## Test plan

Just look at the CI runs in this PR: they are working again!
